### PR TITLE
changes allowing to enable per-jail SYSV IPC namespaces in FreeBSD 11

### DIFF
--- a/iocell.8
+++ b/iocell.8
@@ -1187,13 +1187,59 @@ allow_sysvipc=0 | 1
 .nf
 .fam C
     A process within the jail has access to System V IPC
-    primitives.  In the current jail implementation, System V
-    primitives share a single namespace across the host and
-    jail environments, meaning that processes within a jail
-    would be able to communicate with (and potentially interfere
-    with) processes outside of the jail, and in other jails.
+    primitives. Prior to FreeBSD 11.0, System V primitives
+    share a single namespace across the host and jail
+    environments, meaning that processes within a jail would be
+    able to communicate with (and potentially interfere with)
+    processes outside of the jail, and in other jails.  In
+    FreeBSD 11.0 and later, this setting is deprecated in favor
+    of sysvmsg, sysvsem, and sysvshm.
 
     Default: 0
+    Source: jail(8)
+
+.fam T
+.fi
+sysvmsg=disable | inherit | new
+.PP
+.nf
+.fam C
+    Allow access to SYSV IPC message primitives.  If set to
+    inherit, all IPC objects on the system are visible to this
+    jail, whether they were created by the jail itself, the base
+    system, or other jails.  If set to new, the jail will have
+    its own key namespace, and can only see the objects that it
+    has created; the system (or parent jail) has access to the
+    jail's objects, but not to its keys.  If set to disable, the
+    jail cannot perform any sysvmsg-related system calls.
+    Ignored in FreeBSD 10.3 and earlier.
+
+    Default: new
+    Source: jail(8)
+
+.fam T
+.fi
+sysvsem=disable | inherit | new
+.PP
+.nf
+.fam C
+    Allow access to SYSV IPC semaphore primitives in the same
+    manner as sysvmsg.  Ignored in FreeBSD 10.3 and earlier.
+
+    Default: new
+    Source: jail(8)
+
+.fam T
+.fi
+sysvshm=disable | inherit | new
+.PP
+.nf
+.fam C
+    Allow access to SYSV IPC shared memory primitives in the
+    same manner as sysvmsg.  Ignored in FreeBSD 10.3 and
+    earlier.
+
+    Default: new
     Source: jail(8)
 
 .fam T

--- a/iocell.8.txt
+++ b/iocell.8.txt
@@ -834,13 +834,47 @@ PROPERTIES
   allow_sysvipc=0 | 1
 
     A process within the jail has access to System V IPC
-    primitives.  In the current jail implementation, System V
-    primitives share a single namespace across the host and
-    jail environments, meaning that processes within a jail
-    would be able to communicate with (and potentially interfere
-    with) processes outside of the jail, and in other jails.
+    primitives.  Prior to FreeBSD 11.0, System V primitives
+    share a single namespace across the host and jail
+    environments, meaning that processes within a jail would be
+    able to communicate with (and potentially interfere with)
+    processes outside of the jail, and in other jails.  In
+    FreeBSD 11.0 and later, this setting is deprecated in favor
+    of sysvmsg, sysvsem, and sysvshm.
 
     Default: 0
+    Source: jail(8)
+
+  sysvmsg=disable | inherit | new
+
+    Allow access to SYSV IPC message primitives.  If set to
+    inherit, all IPC objects on the system are visible to this
+    jail, whether they were created by the jail itself, the base
+    system, or other jails.  If set to new, the jail will have
+    its own key namespace, and can only see the objects that it
+    has created; the system (or parent jail) has access to the
+    jail's objects, but not to its keys.  If set to disable, the
+    jail cannot perform any sysvmsg-related system calls.
+    Ignored in FreeBSD 10.3 and earlier.
+
+    Default: disable
+    Source: jail(8)
+
+  sysvsem=disable | inherit | new
+
+    Allow access to SYSV IPC semaphore primitives in the same
+    manner as sysvmsg.  Ignored in FreeBSD 10.3 and earlier.
+
+    Default: disable
+    Source: jail(8)
+
+  sysvshm=disable | inherit | new
+
+    Allow access to SYSV IPC shared memory primitives in the
+    same manner as sysvmsg.  Ignored in FreeBSD 10.3 and
+    earlier.
+
+    Default: disable
     Source: jail(8)
 
   allow_raw_sockets=0 | 1

--- a/lib/ioc-globals
+++ b/lib/ioc-globals
@@ -62,6 +62,9 @@ securelevel="2"
 host_hostuuid=$uuid
 allow_set_hostname=1
 allow_sysvipc=0
+sysvmsg="new"
+sysvsem="new"
+sysvshm="new"
 allow_raw_sockets=0
 allow_chflags=0
 allow_mount=0
@@ -231,6 +234,9 @@ CONF_JAIL="devfs_ruleset
            securelevel
            allow_set_hostname
            allow_sysvipc
+           sysvmsg
+           sysvsem
+           sysvshm
            allow_raw_sockets
            allow_chflags
            allow_mount

--- a/lib/ioc-help
+++ b/lib/ioc-help
@@ -838,13 +838,47 @@ PROPERTIES
   allow_sysvipc=0 | 1
 
     A process within the jail has access to System V IPC
-    primitives.  In the current jail implementation, System V
-    primitives share a single namespace across the host and
-    jail environments, meaning that processes within a jail
-    would be able to communicate with (and potentially interfere
-    with) processes outside of the jail, and in other jails.
+    primitives.  Prior to FreeBSD 11.0, System V primitives
+    share a single namespace across the host and jail
+    environments, meaning that processes within a jail would be
+    able to communicate with (and potentially interfere with)
+    processes outside of the jail, and in other jails.  In
+    FreeBSD 11.0 and later, this setting is deprecated in favor
+    of sysvmsg, sysvsem, and sysvshm.
 
     Default: 0
+    Source: jail(8)
+
+  sysvmsg=disable | inherit | new
+
+    Allow access to SYSV IPC message primitives.  If set to
+    inherit, all IPC objects on the system are visible to this
+    jail, whether they were created by the jail itself, the base
+    system, or other jails.  If set to new, the jail will have
+    its own key namespace, and can only see the objects that it
+    has created; the system (or parent jail) has access to the
+    jail's objects, but not to its keys.  If set to disable, the
+    jail cannot perform any sysvmsg-related system calls.
+    Ignored in FreeBSD 10.3 and earlier.
+
+    Default: new
+    Source: jail(8)
+
+  sysvsem=disable | inherit | new
+
+    Allow access to SYSV IPC semaphore primitives in the same
+    manner as sysvmsg.  Ignored in FreeBSD 10.3 and earlier.
+
+    Default: new
+    Source: jail(8)
+
+  sysvshm=disable | inherit | new
+
+    Allow access to SYSV IPC shared memory primitives in the
+    same manner as sysvmsg.  Ignored in FreeBSD 10.3 and
+    earlier.
+
+    Default: new
     Source: jail(8)
 
   allow_raw_sockets=0 | 1

--- a/lib/ioc-info
+++ b/lib/ioc-info
@@ -445,6 +445,14 @@ __get_jail_prop () {
     # If they don't supply state, then it's a normal property to be returned.
     if [ "${_property}" != "state" ] ; then
         # These are our properties
+        if [ "${_property}" = "sysvmsg" -o "${_property}" = "sysvsem" \
+            -o "${_property}" = "sysvshm" ] ; then
+            if [ "${_value}" = "null" ] ; then
+                _found=1
+                echo "new"
+            fi
+        fi
+
         if [ "${_value}" != "null" ] ; then
             _found=1
             echo "${_value}"

--- a/lib/ioc-rc
+++ b/lib/ioc-rc
@@ -270,10 +270,19 @@ __vnet_start () {
         ${_dataset})"
     _tmpfs="allow.mount.tmpfs=$(__get_jail_prop allow_mount_tmpfs ${_fulluuid} \
         ${_dataset})"
+    _sysvmsg="sysvmsg=$(__get_jail_prop sysvmsg ${_fulluuid} ${_dataset})"
+    _sysvsem="sysvsem=$(__get_jail_prop sysvsem ${_fulluuid} ${_dataset})"
+    _sysvshm="sysvshm=$(__get_jail_prop sysvshm ${_fulluuid} ${_dataset})"
 
     if [ "$(uname -U)" = "903000" ] ; then
       _fdescfs=""
       _tmpfs=""
+    fi
+
+    if [ "$(uname -U)" -lt "100400" ]; then
+      _sysvmsg=""
+      _sysvsem=""
+      _sysvshm=""
     fi
 
     jail -c vnet \
@@ -291,6 +300,9 @@ __vnet_start () {
     allow.set_hostname="$(__get_jail_prop allow_set_hostname ${_fulluuid} \
         ${_dataset})" \
     allow.sysvipc="$(__get_jail_prop allow_sysvipc ${_fulluuid} ${_dataset})" \
+    ${_sysvmsg} \
+    ${_sysvsem} \
+    ${_sysvshm} \
     allow.raw_sockets="$(__get_jail_prop allow_raw_sockets ${_fulluuid} \
         ${_dataset})" \
     allow.chflags="$(__get_jail_prop allow_chflags ${_fulluuid} ${_dataset})" \
@@ -340,6 +352,9 @@ __legacy_start () {
         ${_dataset})"
     _tmpfs="allow.mount.tmpfs=$(__get_jail_prop allow_mount_tmpfs \
         "${_fulluuid}" ${_dataset})"
+    _sysvmsg="sysvmsg=$(__get_jail_prop sysvmsg ${_fulluuid} ${_dataset})"
+    _sysvsem="sysvsem=$(__get_jail_prop sysvsem ${_fulluuid} ${_dataset})"
+    _sysvshm="sysvshm=$(__get_jail_prop sysvshm ${_fulluuid} ${_dataset})"
     # Get the default and current interfaces specified
     _default_iface="$(__get_default_iface)"
     _cur_ip4_iface=$(echo "${_ip4_addr}" | cut -d '|' -f 1)
@@ -349,6 +364,12 @@ __legacy_start () {
     then
       _fdescfs=""
       _tmpfs=""
+    fi
+
+    if [ "$(uname -U)" -lt "100400" ]; then
+      _sysvmsg=""
+      _sysvsem=""
+      _sysvshm=""
     fi
 
     if [ "${_ip4_addr}" = "none" ] ; then
@@ -419,6 +440,9 @@ __legacy_start () {
             "${_fulluuid}" ${_dataset})" \
         allow.sysvipc="$(__get_jail_prop allow_sysvipc "${_fulluuid}" \
             ${_dataset})" \
+        ${_sysvmsg} \
+        ${_sysvsem} \
+        ${_sysvshm} \
         allow.raw_sockets="$(__get_jail_prop allow_raw_sockets "${_fulluuid}" \
             ${_dataset})" \
         allow.chflags="$(__get_jail_prop allow_chflags "${_fulluuid}" \
@@ -480,6 +504,9 @@ __legacy_start () {
             "${_fulluuid}" ${_dataset})" \
         allow.sysvipc="$(__get_jail_prop allow_sysvipc "${_fulluuid}" \
             ${_dataset})" \
+        ${_sysvmsg} \
+        ${_sysvsem} \
+        ${_sysvshm} \
         allow.raw_sockets="$(__get_jail_prop allow_raw_sockets "${_fulluuid}" \
             ${_dataset})" \
         allow.chflags="$(__get_jail_prop allow_chflags "${_fulluuid}" \


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Supply documentation according to [CONTRIBUTING.md](https://github.com/iocell/iocell/blob/master/CONTRIBUTING.md)
- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocell/iocell/blob/master/CONTRIBUTING.md)
- [x] Only open the PR against the `develop` branch.

I tried my best integrating the changes from asomers (https://github.com/asomers) made for iocage regarding system v shared memory into iocell.

Please have mercy with me, as I am new to github..

https://github.com/iocage/iocage/pull/370

Citing the original pull request..

[..] In FreeBSD 11.0 and later, SYSV message, semaphore, and shared memory
primitives can have per-jail namespaces. This is controlled by the
"sysvshm", "sysvmsg", and "sysvsem" jail properties. This commit adds
support for those properties to iocage. The default is to disable sysv
IPC in jails.

Alternatively, I think it would acceptable for iocage to always set those properties to "new", enabling the per-jail namespaces. I think that would be acceptable for almost everyone. I can't think of any good reasons why you would want anything else.
