### PR TITLE
Add a message for "iocell deactivate zpool"

### DIFF
--- a/iocell.8
+++ b/iocell.8
@@ -2121,7 +2121,7 @@ For more information please visit:
 .PP
 .nf
 .fam C
-    https://github.com/iocell/iocell
+    https://github.com/bartekrutkowski/iocell
 
 .fam T
 .fi

--- a/iocell.8.txt
+++ b/iocell.8.txt
@@ -1472,7 +1472,7 @@ HINTS
 
   For more information please visit:
 
-    https://github.com/iocell/iocell
+    https://github.com/bartekrutkowski/iocell
 
 SEE ALSO
   jail(8), ifconfig(8), epair(4), bridge(4), jexec(8), zfs(8), zpool(8),

--- a/lib/ioc-zfs
+++ b/lib/ioc-zfs
@@ -235,7 +235,7 @@ __deactivate () {
     _pool="$1"
 
     echo "The iocell jails and data on ${_pool} must be manually removed with:"
-    echo "    zfs destroy -r ${_pool}"
+    echo "    zfs destroy -r ${_pool}/iocell"
 }
 
 # Accepts two arguments. Which is used as the UUID for the umount operations

--- a/lib/ioc-zfs
+++ b/lib/ioc-zfs
@@ -229,6 +229,15 @@ __clean_snapshots () {
     done
 }
 
+__deactivate () {
+    local _pool
+
+    _pool="$1"
+
+    echo "The iocell jails and data on ${_pool} must be manually removed with:"
+    echo "    zfs destroy -r ${_pool}"
+}
+
 # Accepts two arguments. Which is used as the UUID for the umount operations
 # and what release to use.
 __migrate_basejail () {


### PR DESCRIPTION
Add a message for "iocell deactivate zpool"

Currently, the deactivate command gives an error because the __deactivate() function doesn't exist. This commit adds essentially a stub (letting `deactivate` remain a NO-OP) that suggests how to delete old jails or data, assuming that that's the logical next step after deactivating a zpool.

- [ ]  Supply documentation according to CONTRIBUTING.md
- [X]  Explain the feature
- [X]  Read CONTRIBUTING.md
- [X]  Only open the PR against the develop branch.