### PR TITLE
Fix OS version detection on 10.x

### DIFF
--- a/lib/ioc-rc
+++ b/lib/ioc-rc
@@ -279,7 +279,7 @@ __vnet_start () {
       _tmpfs=""
     fi
 
-    if [ "$(uname -U)" -lt "100400" ]; then
+    if [ "$(uname -U)" -lt "1004000" ]; then
       _sysvmsg=""
       _sysvsem=""
       _sysvshm=""
@@ -366,7 +366,7 @@ __legacy_start () {
       _tmpfs=""
     fi
 
-    if [ "$(uname -U)" -lt "100400" ]; then
+    if [ "$(uname -U)" -lt "1004000" ]; then
       _sysvmsg=""
       _sysvsem=""
       _sysvshm=""


### PR DESCRIPTION
uname -U on 10.3-RELEASE returns "1003000" which is greater than the
value use for comparison ("100400"). The test then fails and iocell
attempts to pass 'sysvmsg', 'sysvsem', 'sysvshm' paramaters to jail(8)
which in turn croaks.

Adjust the comparison value to "1004000" to fix the test.
