### PR TITLE
Bump supported releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ You now have root access within your jail -- enjoy!
   ```
 
 **REQUIREMENTS**
-- FreeBSD 10.3-RELEASE amd64 or newer
+- FreeBSD 11.2-RELEASE amd64 or newer
 - ZFS file system
 - Optional - Kernel compiled with:
 

--- a/lib/ioc-info
+++ b/lib/ioc-info
@@ -2,11 +2,9 @@
 
 # Print supported releases----------------------------------
 __print_release () {
-    supported="12.0-CURRENT
-               11.0-RELEASE
-               10.3-RELEASE
-               10.2-RELEASE
-               9.3-RELEASE"
+    supported="13.0-CURRENT
+               12.0-RELEASE
+               11.2-RELEASE"
 
     echo "Supported releases are: "
     for rel in $(echo $supported) ; do


### PR DESCRIPTION
Versions prior to 11.2 reached their End of Life.

Remove them, and add support for newer ones.

Signed-off-by:	Johannes Meixner <johannes@perceivon.net>