### PR TITLE
Allow to not manipulate bridge interfaces

### DIFF
--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -54,3 +54,7 @@ FAQ
 
 **Is ZFS jailing supported?**
     Yes, please refer to man page.
+
+**How can I prevent from bridge interfaces manipulation on start/stop?**
+    See man page (``iocell set createbridge=off UUID | TAG`` and/or
+    ``iocell set keepbridge=on UUID | TAG``)

--- a/doc/source/networking.rst
+++ b/doc/source/networking.rst
@@ -189,3 +189,13 @@ To start a jail with no IPv4/6 address whatsoever set these properties:
 ``iocell set ip4_addr=none ip6_addr=none UUID|TAG``
 
 ``iocell set defaultrouter=none defaultrouter6=none UUID|TAG``
+
+To not create bridge interfaces on jail start set this property:
+
+``iocell set createbridge=off UUID|TAG``
+
+To keep bridge interfaces on jail shutdown set this property:
+
+``iocell set keepbridge=on UUID|TAG``
+
+*NOTE: You can set these to or on off according to the use case*

--- a/iocell.8
+++ b/iocell.8
@@ -749,6 +749,28 @@ ip4=new | disable | inherit
 
 .fam T
 .fi
+createbridge=on | off
+.PP
+.nf
+.fam C
+    Controls whether default bridge0 and bridge1 will be created
+    on jails's start.
+
+    Default: on
+
+.fam T
+.fi
+keepbridge=on | off
+.PP
+.nf
+.fam C
+    Controls whether bridges bridge0 and bridge1 will be destroyed
+    on jail's shutdown.
+
+    Default: off
+
+.fam T
+.fi
 defaultrouter=none | ipaddress
 .PP
 .nf

--- a/lib/ioc-configure
+++ b/lib/ioc-configure
@@ -225,6 +225,8 @@ __reset_jail_props () {
     host_hostname="$(__get_jail_prop host_hostname ${uuid} ${_dataset})"
     mount_procfs="$(__get_jail_prop mount_procfs ${uuid} ${_dataset})"
     mount_linprocfs="$(__get_jail_prop mount_linprocfs ${uuid} ${_dataset})"
+    createbridge="$(__get_jail_prop createbridge ${uuid} ${_dataset})"
+    keepbridge="$(__get_jail_prop keepbridge ${uuid} ${_dataset})"
 
     __configure_jail ${uuid} ${_dataset}
 }

--- a/lib/ioc-globals
+++ b/lib/ioc-globals
@@ -38,6 +38,8 @@ vnet0_mac="none"
 vnet1_mac="none"
 vnet2_mac="none"
 vnet3_mac="none"
+createbridge="on"
+keepbridge="off"
 
 # Standard jail properties
 devfs_ruleset="4"
@@ -208,7 +210,9 @@ CONF_NET="interfaces
           vnet0_mac
           vnet1_mac
           vnet2_mac
-          vnet3_mac"
+          vnet3_mac
+          createbridge
+          keepbridge"
 
 # Native jail properties
 CONF_JAIL="devfs_ruleset

--- a/lib/ioc-help
+++ b/lib/ioc-help
@@ -534,6 +534,20 @@ PROPERTIES
     Default: new
     Source: jail(8)
 
+  createbridge=on | off
+
+    Controls whether default bridge0 and bridge1 will be created
+    on jails's start.
+
+    Default: on
+
+  keepbridge=on | off
+
+    Controls whether bridges bridge0 and bridge1 will be destroyed
+    on jail's shutdown.
+
+    Default: off
+
   defaultrouter=none | ipaddress
 
     Setting this property to anything other than none will try to configure a

--- a/lib/ioc-info
+++ b/lib/ioc-info
@@ -2,11 +2,10 @@
 
 # Print supported releases----------------------------------
 __print_release () {
-    supported="12.0-CURRENT
-               11.0-RELEASE
-               10.3-RELEASE
-               10.2-RELEASE
-               9.3-RELEASE"
+    supported="14.0-CURRENT
+               13.1-RELEASE
+               13.0-RELEASE
+               12.3-RELEASE"
 
     echo "Supported releases are: "
     for rel in $(echo $supported) ; do

--- a/lib/ioc-network
+++ b/lib/ioc-network
@@ -75,6 +75,9 @@ __networking () {
     #local ip4_list="$(echo $ip4 | sed 's/,/ /g')"
     local ip6_list="$(echo $ip6 | sed 's/,/ /g')"
 
+    local createbridge="$(__get_jail_prop createbridge ${_uuid})"
+    local keepbridge="$(__get_jail_prop keepbridge ${_uuid})"
+
     # Get the default and current interfaces specified
     local default_iface="$(__get_default_iface)"
     local cur_ip4_iface=$(echo "$ip4_addr" | cut -d '|' -f 1)
@@ -94,14 +97,14 @@ __networking () {
             for _b in ${_bridge_ifaces} ; do
                 if [ "${_b}" != "bridge0" ] ; then
                     _bridge_exists="$(echo ${_bridge_ifaces} | grep bridge0)"
-                    if [ -z "${_bridge_exists}" ] ; then
+                    if [ -z "${_bridge_exists}" -a "${createbridge}" == "on" ] ; then
                         ifconfig bridge0 create addm "${default_iface}"
                     else
                         continue
                     fi
                 elif [ "${_b}" != "bridge1" ] ; then
                     _bridge_exists="$(echo ${_bridge_ifaces} | grep bridge1)"
-                    if [ -z "${_bridge_exists}" ] ; then
+                    if [ -z "${_bridge_exists}" -a "${createbridge}" == "on" ] ; then
                         ifconfig bridge1 create
                     else
                         continue
@@ -209,9 +212,9 @@ __networking () {
 
         _bridge_inuse="$(netstat -iWn | grep '^vnet' | \
                        awk '{ print $1 }')"
-        # If no vnet interfaces are using the bridges, let's clean up after
+        # If no vnet interfaces are using the bridges, let us clean up after
         # ourselves
-        if [ -z "${_bridge_inuse}" ] ; then
+        if [ -z "${_bridge_inuse}" -a "${keepbridge}" == "off" ] ; then
             ifconfig bridge0 destroy > /dev/null 2>&1
             ifconfig bridge1 destroy > /dev/null 2>&1
         fi


### PR DESCRIPTION
This PR adds the possibility to toggle bridge create/destroy in situations where these are being created outside iocell's control.
