### PR TITLE
Fix checking for snapshots from earlier upgrades

### DIFF
--- a/lib/ioc-upgrade
+++ b/lib/ioc-upgrade
@@ -239,10 +239,10 @@ __upgrade () {
             awk 'BEGIN { FS = "/" } ; { if (length($NF)==36) { print }}')
         # Check to see if the jail has a stale upgrade snapshot.
         for _fs in ${_jails} ; do
-            _snapcheck="$(zfs list -Ht snap | \
+            _snapcheck="$(zfs list -rHt snap ${pool}/iocell/jails | \
                      egrep "${_fulluuid}.*ioc-upgrade" | \
                      awk '{print $1}')"
-            if [ ! -z ${_snapcheck} ] ; then
+            if [ ! -z "${_snapcheck}" ] ; then
                 __error "${_name} has an existing upgrade snapshot" >&2
                 printf "%1s ${_snapcheck} \n" >&2
                 printf "%1s please remove this before trying to upgrade. \n" >&2


### PR DESCRIPTION
- [x] Supply documentation according to [CONTRIBUTING.md](https://github.com/bartekrutkowski/iocell/blob/master/CONTRIBUTING.md)

No functionality added/changed that requires a change to the manpage/README

- [x] Explain the feature

Before jail upgrades, iocell checked for stale snapshots from earlier upgrades *over the whole system*. This could have wreaked havoc if you had jail datasets backed up (also from other hosts!) on that system - I learned this the hard way.
This fix refines the check by only looking at datasets under "$pool/iocell/jails", which also gives a considerable speed improvement if there are large pools (on spinning rust) on that system.

- [x] Read [CONTRIBUTING.md](https://github.com/bartekrutkowski/iocell/blob/master/CONTRIBUTING.md)
- [x] Only open the PR against the `develop` branch.
