### PR TITLE
doc.txz is gone since 13.0, don't try to download it

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ You now have root access within your jail -- enjoy!
   iocell exec [-u username | -U username] UUID|TAG|ALL command [arg ...]
   iocell export UUID|TAG
   iocell fetch [release=RELEASE | ftphost=ftp.hostname.org | ftpdir=/dir/ |
-                ftpfiles="base.txz doc.txz lib32.txz src.txz"]
+                ftpfiles="base.txz lib32.txz src.txz"]
   iocell get property|all UUID|TAG
   iocell help
   iocell import UUID [property=value]

--- a/iocell.8
+++ b/iocell.8
@@ -19,7 +19,7 @@
 \fBiocell\fP [\fB-v\fP] \fIexec\fP [\fB-u\fP \fIusername\fP | \fB-U\fP \fIusername\fP] UUID|TAG|ALL \fIcommand\fP [\fIarg\fP \.\.\.]
 \fBiocell\fP [\fB-v\fP] \fIexport\fP UUID|TAG
 \fBiocell\fP [\fB-v\fP] \fIfetch\fP [\fB-p\fP|\fB-P\fP] [\fIrelease=RELEASE\fP | ftphost=ftp.hostname.org |
-                  ftpdir=/dir/ | ftpfiles="base.txz doc.txz lib32.txz src.txz"]
+                  ftpdir=/dir/ | ftpfiles="base.txz lib32.txz src.txz"]
                   [ ftplocaldir=/dir/ ] [ \fIcompression=ALGO\fP ]
 \fBiocell\fP [\fB-v\fP] \fIget\fP [\fB-r\fP] property|all UUID|TAG
 \fBiocell\fP [\fB-v\fP] \fIhelp\fP
@@ -248,7 +248,7 @@ how the shell is running each of the commands. It's very verbose.
 .fam T
 .fi
 \fIfetch\fP [\fB-p\fP|\fB-P\fP] [\fIrelease=RELEASE\fP | ftphost=ftp.hostname.org |
-ftpdir=/dir/ | ftpfiles="base.txz doc.txz lib32.txz src.txz"]
+ftpdir=/dir/ | ftpfiles="base.txz lib32.txz src.txz"]
 [ ftplocaldir=/dir/ ] [ \fIcompression=ALGO\fP ]
 .RS
 .PP

--- a/iocell.8.txt
+++ b/iocell.8.txt
@@ -15,7 +15,7 @@ SYNOPSIS
   iocell [-v] exec [-u username | -U username] UUID|TAG|ALL command [arg ...]
   iocell [-v] export UUID|TAG
   iocell [-v] fetch [-p|-P] [release=RELEASE | ftphost=ftp.hostname.org |
-                    ftpdir=/dir/ | ftpfiles="base.txz doc.txz lib32.txz src.txz"]
+                    ftpdir=/dir/ | ftpfiles="base.txz lib32.txz src.txz"]
                     [ ftplocaldir=/dir/ ] [ compression=ALGO ]
   iocell [-v] get [-r] property|all UUID|TAG
   iocell [-v] help
@@ -181,7 +181,7 @@ SUBCOMMANDS
     SHA256 checksum. Jail must be in stopped state before exporting.
 
   fetch [-p|-P] [release=RELEASE | ftphost=ftp.hostname.org |
-        ftpdir=/dir/ | ftpfiles="base.txz doc.txz lib32.txz src.txz"]
+        ftpdir=/dir/ | ftpfiles="base.txz lib32.txz src.txz"]
         [ ftplocaldir=/dir/ ] [ compression=ALGO ]
 
     Used for downloading and updating/patching releases.

--- a/lib/ioc-globals
+++ b/lib/ioc-globals
@@ -144,7 +144,7 @@ sync_tgt_zpool="none"
 
 # FTP variables
 ftphost="ftp.freebsd.org"
-ftpfiles="base.txz doc.txz lib32.txz src.txz"
+ftpfiles="base.txz lib32.txz src.txz"
 
 # Git properties
 gitlocation="https://github.com"

--- a/lib/ioc-help
+++ b/lib/ioc-help
@@ -19,7 +19,7 @@ SYNOPSIS
   iocell [-v] exec [-u username | -U username] UUID|TAG|ALL command [arg ...]
   iocell [-v] export UUID|TAG
   iocell [-v] fetch [-p|-P] [release=RELEASE | ftphost=ftp.hostname.org |
-                    ftpdir=/dir/ | ftpfiles="base.txz doc.txz lib32.txz src.txz"]
+                    ftpdir=/dir/ | ftpfiles="base.txz lib32.txz src.txz"]
                     [ ftplocaldir=/dir/ ] [ compression=ALGO ]
   iocell [-v] get [-r] property|all UUID|TAG
   iocell [-v] help
@@ -185,7 +185,7 @@ SUBCOMMANDS
     SHA256 checksum. Jail must be in stopped state before exporting.
 
   fetch [-p|-P] [release=RELEASE | ftphost=ftp.hostname.org |
-        ftpdir=/dir/ | ftpfiles="base.txz doc.txz lib32.txz src.txz"]
+        ftpdir=/dir/ | ftpfiles="base.txz lib32.txz src.txz"]
         [ ftplocaldir=/dir/ ] [ compression=ALGO ]
 
     Used for downloading and updating/patching releases.


### PR DESCRIPTION
- [x] Supply documentation according to [CONTRIBUTING.md](https://github.com/bartekrutkowski/iocell/blob/master/CONTRIBUTING.md)

~~No new/changed functionality that requires change in the manpage/README~~
Documentation has been updated with the second commit in this PR.

- [x] Explain the feature

Since the 13.0 branch, there is no 'doc.txz' file any more. This patch removes it from $ftpfiles.
We *could* still download it for 12.4-RELEASE via some if-statement, but as the 12-branch will be EOL very soon I choose to be lazy...

- [x] Read [CONTRIBUTING.md](https://github.com/bartekrutkowski/iocell/blob/master/CONTRIBUTING.md)
- [x] Only open the PR against the `develop` branch.
