### PR TITLE
make lookup of supported releases dynamic

### DIFF
--- a/lib/ioc-info
+++ b/lib/ioc-info
@@ -2,12 +2,15 @@
 
 # Print supported releases----------------------------------
 __print_release () {
-    supported="15.0-CURRENT
-               14.0-RELEASE
-               13.2-RELEASE"
+	arch="$(sysctl -n hw.machine_arch)"
+	releases="$(fetch -qo - https://${ftphost}/pub/FreeBSD/releases/$arch/ | \
+				sed -e 's/<[^>]*>//g' | awk -F/ '/RELEASE/ { print $1 }')"
+	snapshots="$(fetch -qo - https://${ftphost}/pub/FreeBSD/snapshots/$arch/ | \
+				sed -e 's/<[^>]*>//g' | awk -F/ '/CURRENT|STABLE/ { print $1 }')"
+
 
     echo "Supported releases are: "
-    for rel in $(echo $supported) ; do
+    for rel in $(echo $releases $snapshots) ; do
         # hack to get printf to both left adjust and have spaces.
         printf "%1s %-s \n" "" "$rel"
     done


### PR DESCRIPTION
- [x] Supply documentation according to [CONTRIBUTING.md](https://github.com/bartekrutkowski/iocell/blob/master/CONTRIBUTING.md)

No new/changed functionality that requires change in the manpage/README

- [x] Explain the feature

Instead of constantly changing the list of presented "supported releases" for 'iocell fetch' manually, make the process dynamic by fetching the currently available releases and snapshots from $ftphost

- [x] Read [CONTRIBUTING.md](https://github.com/bartekrutkowski/iocell/blob/master/CONTRIBUTING.md)
- [x] Only open the PR against the `develop` branch.
