### PR TITLE
More vnets

### DIFF
--- a/iocell.8
+++ b/iocell.8
@@ -815,7 +815,7 @@ interfaces=vnet0:bridge0,vnet1:bridge1 | vnet0:bridge0
 .nf
 .fam C
     By default there are two interfaces specified with their bridge
-    association. Up to four interfaces are supported. Interface configurations
+    association. Up to ten interfaces are supported. Interface configurations
     are separated by commas. Format is interface:bridge, where left value is
     the virtual VNET interface name, right value is the bridge name where the
     virtual interface should be attached.

--- a/iocell.8.txt
+++ b/iocell.8.txt
@@ -556,7 +556,7 @@ PROPERTIES
   interfaces=vnet0:bridge0,vnet1:bridge1 | vnet0:bridge0
 
     By default there are two interfaces specified with their bridge
-    association. Up to four interfaces are supported. Interface configurations
+    association. Up to ten interfaces are supported. Interface configurations
     are separated by commas. Format is interface:bridge, where left value is
     the virtual VNET interface name, right value is the bridge name where the
     virtual interface should be attached.

--- a/lib/ioc-configure
+++ b/lib/ioc-configure
@@ -82,7 +82,43 @@ __configure_jail () {
                            esac
                            _value="${vnet3_mac}"
                     ;;
-                *) _value="${_prop}"
+                vnet4_mac) case "${vnet4_mac}" in
+                               "-") vnet4_mac="none"
+                                   ;;
+                           esac
+                           _value="${vnet4_mac}"
+                    ;;
+                vnet5_mac) case "${vnet5_mac}" in
+                               "-") vnet5_mac="none"
+                                   ;;
+                           esac
+                           _value="${vnet5_mac}"
+                    ;;
+                vnet6_mac) case "${vnet6_mac}" in
+                               "-") vnet6_mac="none"
+                                   ;;
+                           esac
+                           _value="${vnet6_mac}"
+                    ;;
+                vnet7_mac) case "${vnet7_mac}" in
+                               "-") vnet7_mac="none"
+                                   ;;
+                           esac
+                           _value="${vnet7_mac}"
+                    ;;
+                vnet8_mac) case "${vnet8_mac}" in
+                               "-") vnet8_mac="none"
+                                   ;;
+                           esac
+                           _value="${vnet8_mac}"
+                    ;;
+                 vnet9_mac) case "${vnet9_mac}" in
+                               "-") vnet9_mac="none"
+                                   ;;
+                           esac
+                           _value="${vnet9_mac}"
+                    ;;
+             *) _value="${_prop}"
                     ;;
             esac
 
@@ -211,6 +247,12 @@ __reset_jail_props () {
     vnet1_mac="$(__get_jail_prop vnet1_mac ${uuid} ${_dataset})"
     vnet2_mac="$(__get_jail_prop vnet2_mac ${uuid} ${_dataset})"
     vnet3_mac="$(__get_jail_prop vnet3_mac ${uuid} ${_dataset})"
+    vnet4_mac="$(__get_jail_prop vnet4_mac ${uuid} ${_dataset})"
+    vnet5_mac="$(__get_jail_prop vnet5_mac ${uuid} ${_dataset})"
+    vnet6_mac="$(__get_jail_prop vnet6_mac ${uuid} ${_dataset})"
+    vnet7_mac="$(__get_jail_prop vnet7_mac ${uuid} ${_dataset})"
+    vnet8_mac="$(__get_jail_prop vnet8_mac ${uuid} ${_dataset})"
+    vnet9_mac="$(__get_jail_prop vnet9_mac ${uuid} ${_dataset})"
     basedirs="$(__get_jail_prop basedirs ${uuid} ${_dataset})"
     hack88="$(__get_jail_prop hack88 ${uuid} ${_dataset})"
     jail_zfs_dataset="$(__get_jail_prop jail_zfs_dataset ${uuid} ${_dataset})"

--- a/lib/ioc-globals
+++ b/lib/ioc-globals
@@ -38,6 +38,12 @@ vnet0_mac="none"
 vnet1_mac="none"
 vnet2_mac="none"
 vnet3_mac="none"
+vnet4_mac="none"
+vnet5_mac="none"
+vnet6_mac="none"
+vnet7_mac="none"
+vnet8_mac="none"
+vnet9_mac="none"
 createbridge="on"
 keepbridge="off"
 
@@ -211,6 +217,12 @@ CONF_NET="interfaces
           vnet1_mac
           vnet2_mac
           vnet3_mac
+          vnet4_mac
+          vnet5_mac
+          vnet6_mac
+          vnet7_mac
+          vnet8_mac
+          vnet9_mac
           createbridge
           keepbridge"
 

--- a/lib/ioc-info
+++ b/lib/ioc-info
@@ -324,7 +324,8 @@ __list_jails () {
 __list_jails_warden () {
     local _jails _switch _ioc_jids _uuid _boot _tag _template _interfaces \
           _ip4_addr _ip6_addr _vnet _vnet0_mac \
-          _vnet1_mac _vnet2_mac _vnet3_mac _type
+          _vnet1_mac _vnet2_mac _vnet3_mac _vnet4_mac _vnet5_mac _vnet6_mac \
+		  _vnet7_mac _vnet8_mac _vnet9_mac _type
 
     _jails=$(__find_jail "ALL" | \
             awk 'BEGIN { FS = "/" } ; { if (length($NF)==36) { print }}')
@@ -343,6 +344,12 @@ __list_jails_warden () {
         _vnet1_mac=$(__get_jail_prop vnet1_mac "${_uuid}" "${_jail}")
         _vnet2_mac=$(__get_jail_prop vnet2_mac "${_uuid}" "${_jail}")
         _vnet3_mac=$(__get_jail_prop vnet3_mac "${_uuid}" "${_jail}")
+        _vnet4_mac=$(__get_jail_prop vnet4_mac "${_uuid}" "${_jail}")
+        _vnet5_mac=$(__get_jail_prop vnet5_mac "${_uuid}" "${_jail}")
+        _vnet6_mac=$(__get_jail_prop vnet6_mac "${_uuid}" "${_jail}")
+        _vnet7_mac=$(__get_jail_prop vnet7_mac "${_uuid}" "${_jail}")
+        _vnet8_mac=$(__get_jail_prop vnet8_mac "${_uuid}" "${_jail}")
+        _vnet9_mac=$(__get_jail_prop vnet9_mac "${_uuid}" "${_jail}")
         _type=$(__get_jail_prop type "${_uuid}" "${_jail}")
 
         # get jid for iocell jails

--- a/lib/ioc-network
+++ b/lib/ioc-network
@@ -71,7 +71,7 @@ __networking () {
     local defaultgw="$(__get_jail_prop defaultrouter ${_uuid} $_dataset)"
     local defaultgw6="$(__get_jail_prop defaultrouter6 ${_uuid} $_dataset)"
     local nics="$(__get_jail_prop interfaces ${_uuid} $_dataset\
-               |awk 'BEGIN { FS = "," } ; { print $1,$2,$3,$4 }')"
+               |awk 'BEGIN { FS = "," } ; { print $1,$2,$3,$4,$5,$6,$7,$8,$9,$10 }')"
     #local ip4_list="$(echo $ip4 | sed 's/,/ /g')"
     local ip6_list="$(echo $ip6 | sed 's/,/ /g')"
 


### PR DESCRIPTION
- [x] Supply documentation according to [CONTRIBUTING.md](https://github.com/bartekrutkowski/iocell/blob/master/CONTRIBUTING.md)

The manpage has been updated to reflect the higher number of possible interfaces

- [x] Explain the feature

iocell only supported creation of 4 vnet interfaces in a jail, which is sufficient for most use cases. However, thanks to improvements to jails like e.g. being able to run a DHCP server or even PF in a jail, one can now host DHCP servers or even whole gateways/firewalls within jails, which often should be attached to more than only 4 networks/vlans.

The new number of interfaces (10) is equally arbitrary as the previous number, and the implementation could (should?) be a bit more elegant and dynamic, but I couldn't figure out a proper way to handle that e.g. for the (static) template files without breaking existing setups.
Suggestions or other input on this are welcome!

- [x] Read [CONTRIBUTING.md](https://github.com/bartekrutkowski/iocell/blob/master/CONTRIBUTING.md)
- [x] Only open the PR against the `develop` branch.
