### PR TITLE
Fix set default

### DIFF
--- a/iocell.8
+++ b/iocell.8
@@ -483,7 +483,8 @@ restart \fIUUID\fP|\fITAG\fP
 .PP
 .nf
 .fam C
-    Set one or more properties to the supplied value.
+    Set one or more properties to the supplied value. If TAG=default the property is set as
+    a global default, but doesn't touch the configuration of existing jails.
 
 .fam T
 .fi

--- a/iocell.8.txt
+++ b/iocell.8.txt
@@ -340,7 +340,8 @@ SUBCOMMANDS
 
   set property=value [property=value] UUID|TAG
 
-    Set one or more properties to the supplied value.
+    Set one or more properties to the supplied value. If TAG=default the property is set as
+	a global default, but doesn't touch the configuration of existing jails.
 
   snaplist UUID|TAG
 

--- a/lib/ioc-common
+++ b/lib/ioc-common
@@ -360,6 +360,9 @@ __set_jail_prop () {
 
     if [ "${_type}" = "custom" ] ; then
         _mountpoint="$(__get_jail_prop mountpoint ${_fulluuid} ${_dataset})"
+			if [ "${_name}" = "default" ] ; then
+			_mountpoint="${iocroot}"
+			fi
         __ucl_set "${_mountpoint}" "${_pname}" "${_pval}"
     elif [ "${_type}" = "native" ] ; then
         zfs set ${_pname}="${_pval}" ${_dataset}
@@ -875,24 +878,29 @@ __pkg_wrapper () {
 # Requires three arguments. The mountpoint of the jail, the property to be set,
 # and the value of that property.
 __ucl_set () {
-    local _mountpoint _property _value _create
+    local _mountpoint _property _value _create _conffile
 
     _mountpoint="$1"
     _property="$2"
     _value="$3"
     _create="$4"
+	_conffile="config"
+
+	if [ "${_mountpoint}" = "${iocroot}" ]; then
+		_conffile=".default"
+	fi
 
     #If creating a jail this will not exist.
     if [ "${_create}" != "1" ] ; then
-        uclcmd set -u -f ${_mountpoint}/config -o ${_mountpoint}/config.new \
+        uclcmd set -u -f ${_mountpoint}/${_conffile} -o ${_mountpoint}/${_conffile}.new \
             -t string -- "${_property}" "${_value}"
 
         if [ $? -eq 0 ] ; then
-            mv ${_mountpoint}/config ${_mountpoint}/config.old
-            mv ${_mountpoint}/config.new ${_mountpoint}/config
+            mv ${_mountpoint}/${_conffile} ${_mountpoint}/${_conffile}.old
+            mv ${_mountpoint}/${_conffile}.new ${_mountpoint}/${_conffile}
         fi
     else
-        uclcmd set -u -f ${_mountpoint}/config -t string -- "${_property}" \
+        uclcmd set -u -f ${_mountpoint}/${_conffile} -t string -- "${_property}" \
             "${_value}"
     fi
 }

--- a/lib/ioc-info
+++ b/lib/ioc-info
@@ -133,6 +133,10 @@ __find_jail () {
             done
         fi
 
+		if [ "${_name}" = "default" ] ; then
+			_jlist="default"
+		fi
+
         if [ "$(echo ${_jlist}|wc -w)" -eq "1" ] ; then
             # remove whitespace
             echo "${_jlist}" | xargs


### PR DESCRIPTION
we need to handle a different config file (.default) if the given jailname is 'default'. this patch catches this exception at __ucl_set().

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Supply documentation according to [CONTRIBUTING.md](https://github.com/bartekrutkowski/iocell/blob/master/CONTRIBUTING.md)
The manpage has been modified to reflect that setting new 'default' properties won't touch existing jails.

- [x] Explain the feature
This fixes the already present but not functional feature of setting default properties in the global '.default' config file by running `iocell set property=value default`.
This addresses #24  

- [x] Read [CONTRIBUTING.md](https://github.com/bartekrutkowski/iocell/blob/master/CONTRIBUTING.md)
- [x] Only open the PR against the `develop` branch.
