### PR TITLE
fix rollback for basejails

### DIFF
--- a/lib/ioc-snapshot
+++ b/lib/ioc-snapshot
@@ -156,7 +156,7 @@ __rollback () {
 
     if [ ! -z "${_snapshot}" ] ; then
         for _fs in ${_fs_list} ; do
-            if [ "${_jail_type}" = "basejail" -a "${_fs}" = "${_dataset}/root" ] ; then
+            if [ "${_jail_type}" = "basejail" -a "${_fs}" != "${_dataset}/root" ] ; then
                 continue
             fi
             echo "* Rolling back to ${_fs}@${_snapshot}"


### PR DESCRIPTION
for basejails snapshots are only created for the <uuid>/root dataset, not the parent <uuid> dataset.
So for basejails we should skip the rollback for datasets that are NOT "${_dataset}/root", because there is no snapshot for ${_dataset}

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Supply documentation according to [CONTRIBUTING.md](https://github.com/bartekrutkowski/iocell/blob/master/CONTRIBUTING.md)
bugfix, no change in documented function/behavior

- [x] Explain the feature
This fixes #27 

- [x] Read [CONTRIBUTING.md](https://github.com/bartekrutkowski/iocell/blob/master/CONTRIBUTING.md)
- [x] Only open the PR against the `develop` branch.
