### PR TITLE
clarify usage of `iocell exec`

### DIFF
--- a/iocell.8
+++ b/iocell.8
@@ -233,8 +233,11 @@ how the shell is running each of the commands. It's very verbose.
 .PP
 .nf
 .fam C
-    Execute command inside the jail. This is simply an iocell UUID/tag wrapper
+    Execute \fIcommand\fP inside the jail. This is simply an iocell UUID/tag wrapper
     for jexec(8).
+    The \fIcommand\fP that is handed over to jexec(8) gets quoted ("\fIcommand\fP [\fIarg\fP \.\.\.]"),
+    so any quotes within the command part have to be escaped or iocell exec might
+    break.
 
 .fam T
 .fi

--- a/iocell.8.txt
+++ b/iocell.8.txt
@@ -174,6 +174,9 @@ SUBCOMMANDS
 
     Execute command inside the jail. This is simply an iocell UUID/tag wrapper
     for jexec(8).
+    The command that is handed over to jexec(8) gets quoted ("command [arg ...]"),
+    so any quotes within the command part have to be escaped or iocell exec might
+    break.
 
   export UUID|TAG
 


### PR DESCRIPTION
The command handed over to jexec is already quoted; this might cause confusion (see #28  ). This addition clarifies what goes on behind the scenes and also gives a hint to escape any quotes that might be needed in the command.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Supply documentation according to [CONTRIBUTING.md](https://github.com/bartekrutkowski/iocell/blob/master/CONTRIBUTING.md)
- [x] Explain the feature
no new feature
- [x] Read [CONTRIBUTING.md](https://github.com/bartekrutkowski/iocell/blob/master/CONTRIBUTING.md)
- [x] Only open the PR against the `develop` branch.
