### PR TITLE
add jail option 'allow.mount.fdescfs' which is needed to run samba >4.13 in a jail

### DIFF
--- a/iocell.8
+++ b/iocell.8
@@ -1333,6 +1333,22 @@ allow_mount_devfs=0 | 1
 
 .fam T
 .fi
+allow_mount_fdescfs=0 | 1
+.PP
+.nf
+.fam C
+    privileged users inside the jail will be able to mount
+    and unmount the fdescfs file system.  This permission is
+    effective only together with allow.mount and if
+    enforce_statfs is set to a value lower than 2.  Please
+    consider restricting the devfs ruleset with the
+    devfs_ruleset option.
+
+    Default: 0
+    Source: jail(8)
+
+.fam T
+.fi
 allow_mount_nullfs=0 | 1
 .PP
 .nf

--- a/iocell.8.txt
+++ b/iocell.8.txt
@@ -928,6 +928,18 @@ PROPERTIES
     Default: 0
     Source: jail(8)
 
+  allow_mount_fdescfs=0 | 1
+
+    privileged users inside the jail will be able to mount
+    and unmount the fdescfs file system.  This permission is
+    effective only together with allow.mount and if
+    enforce_statfs is set to a value lower than 2.  Please
+    consider restricting the devfs ruleset with the
+    devfs_ruleset option.
+
+    Default: 0
+    Source: jail(8)
+
   allow_mount_nullfs=0 | 1
 
     privileged users inside the jail will be able to mount

--- a/lib/ioc-globals
+++ b/lib/ioc-globals
@@ -258,6 +258,7 @@ CONF_JAIL="devfs_ruleset
            allow_chflags
            allow_mount
            allow_mount_devfs
+           allow_mount_fdescfs
            allow_mount_nullfs
            allow_mount_procfs
            allow_mount_tmpfs

--- a/lib/ioc-globals
+++ b/lib/ioc-globals
@@ -77,6 +77,7 @@ allow_raw_sockets=0
 allow_chflags=0
 allow_mount=0
 allow_mount_devfs=0
+allow_mount_fdescfs=0
 allow_mount_nullfs=0
 allow_mount_procfs=0
 allow_mount_tmpfs=0

--- a/lib/ioc-help
+++ b/lib/ioc-help
@@ -946,6 +946,18 @@ PROPERTIES
     Default: 0
     Source: jail(8)
 
+  allow_mount_devfs=0 | 1
+
+    privileged users inside the jail will be able to mount
+    and unmount the fdesfs file system.  This permission is
+    effective only together with allow.mount and if
+    enforce_statfs is set to a value lower than 2.  Please
+    consider restricting the devfs ruleset with the
+    devfs_ruleset option.
+
+    Default: 0
+    Source: jail(8)
+
   allow_mount_nullfs=0 | 1
 
     privileged users inside the jail will be able to mount

--- a/lib/ioc-rc
+++ b/lib/ioc-rc
@@ -309,6 +309,8 @@ __vnet_start () {
     allow.mount="$(__get_jail_prop allow_mount ${_fulluuid} ${_dataset})" \
     allow.mount.devfs="$(__get_jail_prop allow_mount_devfs ${_fulluuid} \
         ${_dataset})" \
+    allow.mount.fdescfs="$(__get_jail_prop allow_mount_fdescfs ${_fulluuid} \
+        ${_dataset})" \
     allow.mount.nullfs="$(__get_jail_prop allow_mount_nullfs ${_fulluuid} \
         ${_dataset})" \
     allow.mount.procfs="$(__get_jail_prop allow_mount_procfs ${_fulluuid} \
@@ -451,6 +453,8 @@ __legacy_start () {
             ${_dataset})" \
         allow.mount.devfs="$(__get_jail_prop allow_mount_devfs "${_fulluuid}" \
             ${_dataset})" \
+        allow.mount.fdescfs="$(__get_jail_prop allow_mount_fdescfs ${_fulluuid} \
+            ${_dataset})" \
         allow.mount.nullfs="$(__get_jail_prop allow_mount_nullfs \
             "${_fulluuid}" ${_dataset})" \
         allow.mount.procfs="$(__get_jail_prop allow_mount_procfs \
@@ -514,6 +518,8 @@ __legacy_start () {
         allow.mount="$(__get_jail_prop allow_mount "${_fulluuid}" \
             ${_dataset})" \
         allow.mount.devfs="$(__get_jail_prop allow_mount_devfs "${_fulluuid}" \
+            ${_dataset})" \
+        allow.mount.fdescfs="$(__get_jail_prop allow_mount_fdescfs ${_fulluuid} \
             ${_dataset})" \
         allow.mount.nullfs="$(__get_jail_prop allow_mount_nullfs \
             "${_fulluuid}" ${_dataset})" \


### PR DESCRIPTION


Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Supply documentation according to [CONTRIBUTING.md](https://github.com/bartekrutkowski/iocell/blob/master/CONTRIBUTING.md)

manpages and help have been updated with the new option


- [x] Explain the feature

This patch adds the jail option 'allow.mount.fdescfs' which is needed to run samba >4.13 in a jail.
Previously this option was set globally via sysctls security.jail.mount_fdescfs_allowed and security.jail.param.allow.mount.fdescfs, which have been deprecated in favour of per-jail options.

- [x] Read [CONTRIBUTING.md](https://github.com/bartekrutkowski/iocell/blob/master/CONTRIBUTING.md)
- [x] Only open the PR against the `develop` branch.
