### PR TITLE
fix checking of existing bridges

### DIFF
--- a/lib/ioc-network
+++ b/lib/ioc-network
@@ -82,8 +82,7 @@ __networking () {
     local default_iface="$(__get_default_iface)"
     local cur_ip4_iface=$(echo "$ip4_addr" | cut -d '|' -f 1)
     local cur_ip6_iface=$(echo "$ip6_addr" | cut -d '|' -f 1)
-    _bridge_ifaces="$(netstat -iWn | egrep 'bridge0|bridge1' | \
-                    awk '{ print $1 }')"
+	_bridge_ifaces="$(ifconfig -g bridge)"
 
     # Change the DEFAULT tag to correct iface
     nics=$(echo $nics | sed "s/DEFAULT/$default_iface/g")


### PR DESCRIPTION
The comment at line 92ff states "Check to see if >any< bridges exist[...]", while it actually checks for the hard-coded bridges "bridge0" and "bridge1". This causes iocell to always create those two bridges if present bridges on the system have other names.
Because the default route interface is being added to 'bridge0', the interface resets and drops all connections - on a jailhost this might be the default mgmt interface which carries the connection over which iocell was invoked and thus being terminated in the middle of starting the jail.

This Fix changes the grep'ing for bridge0|bridge1 to simply checking for interfaces belonging to the 'bridge' group via 'ifconfig -g bridge'.


Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Supply documentation according to [CONTRIBUTING.md](https://github.com/bartekrutkowski/iocell/blob/master/CONTRIBUTING.md)
bugfix; no update to documentation required

- [x] Explain the feature
fixes the behavior of how iocell checks for bridges and decides if it creates the default bridge0 and bridge1

- [x] Read [CONTRIBUTING.md](https://github.com/bartekrutkowski/iocell/blob/master/CONTRIBUTING.md)
- [x] Only open the PR against the `develop` branch.
