### PR TITLE
Add support for vnet.interface parameter via vnet_interfaces property

### DIFF
--- a/iocell.8
+++ b/iocell.8
@@ -645,6 +645,21 @@ vnet=on | off
 
 .fam T
 .fi
+vnet_interfaces=none | interfacename(s)
+.PP
+.nf
+.fam C
+    An interface or comma-separated list of interfaces to give to a vnet-enabled
+    jail. This allows to pass e.g. SR-IOV network VFs directly into a jail.
+    Each list element is passed as vnet.interface to the jail command.
+    This also requires the devfs ruleset 5 (jail_vnet) and allow_raw_sockets=1
+    being set.
+
+    Default: none
+    Source: jail(8)
+
+.fam T
+.fi
 bpf=on | off
 .PP
 .nf

--- a/iocell.8.txt
+++ b/iocell.8.txt
@@ -446,6 +446,17 @@ PROPERTIES
     Default: auto-guess
     Source: local
 
+  vnet_interfaces=none | interfacename(s)
+
+    An interface or comma-separated list of interfaces to give to a vnet-enabled
+    jail. This allows to pass e.g. SR-IOV network VFs directly into a jail.
+    Each list element is passed as vnet.interface to the jail command.
+    This also requires the devfs ruleset 5 (jail_vnet) and allow_raw_sockets=1
+    being set.
+
+    Default: none
+    Source: jail(8)
+
   bpf=on | off
 
     This controls whether to start the jail with BPF devices enabled.

--- a/lib/ioc-globals
+++ b/lib/ioc-globals
@@ -18,6 +18,7 @@ fi
 ipv6="on"
 
 interfaces="vnet0:bridge0,vnet1:bridge1"
+vnet_interfaces="none"
 host_domainname="none"
 host_hostname=$uuid
 exec_fib=0
@@ -198,6 +199,7 @@ CONF_RCTL="memoryuse
 # Networking configuration
 CONF_NET="interfaces
           vnet
+          vnet_interfaces
           host_domainname
           host_hostname
           ip4_addr

--- a/lib/ioc-help
+++ b/lib/ioc-help
@@ -450,6 +450,17 @@ PROPERTIES
     Default: auto-guess
     Source: local
 
+  vnet_interfaces=none | interfacename(s)
+
+    An interface or comma-separated list of interfaces to give to a vnet-enabled
+    jail. This allows to pass e.g. SR-IOV network VFs directly into a jail.
+    Each list element is passed as vnet.interface to the jail command.
+    This also requires the devfs ruleset 5 (jail_vnet) and allow_raw_sockets=1
+    being set.
+
+    Default: none
+    Source: jail(8)
+
   bpf=on | off
 
     This controls whether to start the jail with BPF devices enabled.

--- a/lib/ioc-rc
+++ b/lib/ioc-rc
@@ -273,6 +273,13 @@ __vnet_start () {
     _sysvmsg="sysvmsg=$(__get_jail_prop sysvmsg ${_fulluuid} ${_dataset})"
     _sysvsem="sysvsem=$(__get_jail_prop sysvsem ${_fulluuid} ${_dataset})"
     _sysvshm="sysvshm=$(__get_jail_prop sysvshm ${_fulluuid} ${_dataset})"
+    if [ "$(__get_jail_prop vnet_interfaces ${_fulluuid} ${_dataset})" = "none" ]; then
+      _vnetifs=""
+    else
+      _vnetifs="$(__get_jail_prop vnet_interfaces ${_fulluuid} ${_dataset} | \
+          awk 'BEGIN { FS="," } { for ( iface = 1; iface <= NF; iface++) \
+          printf "vnet.interface=" $iface " " }')"
+    fi
 
     if [ "$(uname -U)" = "903000" ] ; then
       _fdescfs=""
@@ -286,6 +293,7 @@ __vnet_start () {
     fi
 
     jail -c vnet \
+    ${_vnetifs} \
     name="ioc-${_fulluuid}" \
     host.domainname="$(__get_jail_prop host_domainname ${_fulluuid} \
         ${_dataset})" \


### PR DESCRIPTION
This adds support for the vnet.interface jail parameter, which allows to directly pass interfaces (mainly SR-IOV VFs) to a jail. The vnet_interfaces property can be set to a single interface or a comma-separated list of interfaces; which are passed as vnet.interface parameters to jail(8).
The default is "none"

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Supply documentation according to [CONTRIBUTING.md](https://github.com/bartekrutkowski/iocell/blob/master/CONTRIBUTING.md)
ioc-help as well as iocell.8 and iocell.8.txt have been updated to describe the new feature

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/bartekrutkowski/iocell/blob/master/CONTRIBUTING.md)
- [x] Only open the PR against the `develop` branch.
